### PR TITLE
Reset turnstile without reloading razor component

### DIFF
--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -10,7 +10,12 @@
            Theme="@TurnstileTheme.light"
            OnCallback="@TurnstileCallback"
            OnErrorCallback="@TurnstileErrorCallback"
-           ResponseField="@false" />
+           ResponseField="@false" 
+           @ref="turnstile"/>
+
+<button @onclick="RefreshTurnstile">
+    Reload Turnstile
+</button>
 
 <h3 class="mt-3">Token</h3>
 @if (_turnstileToken != null)
@@ -23,6 +28,8 @@ else
 }
 
 @code {
+    private Turnstile turnstile = default!;
+
     private string? _turnstileToken;
 
     private void TurnstileCallback(string token)
@@ -34,4 +41,10 @@ else
     {
         Console.WriteLine($"Turnstile Error: {message}");
     }
+
+    private async void RefreshTurnstile()
+    {
+        await turnstile.Reset();
+    }
+
 }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -13,8 +13,8 @@
            ResponseField="@false" 
            @ref="turnstile"/>
 
-<button @onclick="RefreshTurnstile">
-    Reload Turnstile
+<button @onclick="ResetTurnstile">
+    Reset Turnstile
 </button>
 
 <h3 class="mt-3">Token</h3>
@@ -42,7 +42,7 @@ else
         Console.WriteLine($"Turnstile Error: {message}");
     }
 
-    private async void RefreshTurnstile()
+    private async void ResetTurnstile()
     {
         await turnstile.ResetAsync();
     }

--- a/samples/BlazorWebAssembly/Pages/Index.razor
+++ b/samples/BlazorWebAssembly/Pages/Index.razor
@@ -44,7 +44,7 @@ else
 
     private async void RefreshTurnstile()
     {
-        await turnstile.Reset();
+        await turnstile.ResetAsync();
     }
 
 }

--- a/src/BlazorTurnstile/Interop.cs
+++ b/src/BlazorTurnstile/Interop.cs
@@ -22,6 +22,12 @@ internal class Interop : IAsyncDisposable
         await module.InvokeVoidAsync("render", component, widgetElement, parameters);
     }
 
+    public async ValueTask ResetAsync()
+    {
+        var module = await moduleTask.Value;
+        await module.InvokeVoidAsync("reset");
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (moduleTask.IsValueCreated)

--- a/src/BlazorTurnstile/Turnstile.razor
+++ b/src/BlazorTurnstile/Turnstile.razor
@@ -109,7 +109,7 @@
         await OnErrorCallback.InvokeAsync(message);
     }
 
-    public async Task Reset()
+    public async Task ResetAsync()
     {
         if (_interop is not null)
         {

--- a/src/BlazorTurnstile/Turnstile.razor
+++ b/src/BlazorTurnstile/Turnstile.razor
@@ -109,6 +109,17 @@
         await OnErrorCallback.InvokeAsync(message);
     }
 
+    public async Task Reset()
+    {
+        if (_interop is not null)
+        {
+            Token = null;
+            await TokenChanged.InvokeAsync(Token);
+
+            await _interop.ResetAsync();            
+        }
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_interop is not null)

--- a/src/BlazorTurnstile/wwwroot/interop.js
+++ b/src/BlazorTurnstile/wwwroot/interop.js
@@ -5,3 +5,7 @@ export function render(obj, element, parameters) {
 
     turnstile.render(element, parameters);
 }
+
+export function reset() {
+    turnstile.reset();
+}


### PR DESCRIPTION
Added a ResetAsync method to Turnstile.razor that invokes its JS conterpart and resets the Token variable
Could have also called the `turnstile.render` function but the intended method is `turnstile..reset`.