### PR TITLE
fix: JSDisconnectedException thrown on blazor server

### DIFF
--- a/src/BlazorTurnstile/Turnstile.razor
+++ b/src/BlazorTurnstile/Turnstile.razor
@@ -151,12 +151,20 @@
     {
         if (_interop != null)
         {
-            await _interop.DisposeAsync();
-
-            if (WidgetId != null)
+            try
             {
-                await _interop.RemoveAsync(WidgetId);
-                WidgetId = null;
+                if (WidgetId != null)
+                {
+                    await _interop.RemoveAsync(WidgetId);
+                    WidgetId = null;
+                }
+
+                await _interop.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+                // this exception may be thrown when closing or reloading the page on blazor server
+                // it is safe to ignore
             }
         }
 


### PR DESCRIPTION
We need to catch following exception:

```
Microsoft.JSInterop.JSDisconnectedException: JavaScript interop calls cannot be issued at this time. This is because the circuit has disconnected and is being disposed.
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, CancellationToken cancellationToken, Object[] args)
   at Microsoft.JSInterop.JSRuntime.InvokeAsync[TValue](Int64 targetInstanceId, String identifier, Object[] args)
   at Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync(IJSRuntime jsRuntime, String identifier, Object[] args)
   at Microsoft.JSInterop.Implementation.JSObjectReference.DisposeAsync()
   at BlazorTurnstile.Interop.DisposeAsync()
   at BlazorTurnstile.Turnstile.DisposeAsync()
   at Microsoft.AspNetCore.Components.RenderTree.Renderer.<>c__DisplayClass85_0.<<Dispose>g__HandleAsyncExceptions|1>d.MoveNext()
```

I also noticed that `_interop.DisposeAsync()` was being called before `_interop.RemoveAsync(WidgetId)` which doesn't make a lot of sense so I switched the order.